### PR TITLE
Fix Regions

### DIFF
--- a/src/client/hsr/hsr.interface.ts
+++ b/src/client/hsr/hsr.interface.ts
@@ -1,8 +1,8 @@
 import { IHoyolabOptions } from '../hoyolab'
 
 export enum HsrRegion {
-  USA = 'prod_official_asia',
-  EUROPE = 'prod_official_euro',
+  USA = 'prod_official_usa',
+  EUROPE = 'prod_official_eur',
   ASIA = 'prod_official_asia',
   CHINA_TAIWAN = 'prod_official_cht',
 }


### PR DESCRIPTION
USA used to point to ASIA and Europe is supposed to end with `eur` not `euro`